### PR TITLE
Deploy portfolio to mini app and vercel

### DIFF
--- a/api/index.py
+++ b/api/index.py
@@ -1,0 +1,13 @@
+import os
+
+# Vercel Python Serverless Function entry for Flask via vercel-wsgi
+from vercel_wsgi import handle
+
+# Import the Flask app instance
+from app import app as flask_app
+
+
+def handler(event, context):
+    # Delegate to vercel-wsgi adapter
+    return handle(flask_app, event, context)
+

--- a/app.py
+++ b/app.py
@@ -1,11 +1,15 @@
 from flask import Flask, render_template, request, redirect
+import os
 import sqlite3
 
 app = Flask(__name__)
 
 # 1️⃣ Create a database with a table (only runs once)
 def init_db():
-    with sqlite3.connect("database.db") as conn:
+    db_path = os.environ.get("VERCEL", None)
+    # Use ephemeral /tmp storage on Vercel; default to local file otherwise
+    database_file = "/tmp/database.db" if db_path is not None else "database.db"
+    with sqlite3.connect(database_file) as conn:
         conn.execute("""
             CREATE TABLE IF NOT EXISTS messages (
                 id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -36,7 +40,9 @@ def contact():
         name = request.form['name']
         email = request.form['email']
         message = request.form['message']
-        with sqlite3.connect("database.db") as conn:
+        db_path = os.environ.get("VERCEL", None)
+        database_file = "/tmp/database.db" if db_path is not None else "database.db"
+        with sqlite3.connect(database_file) as conn:
             conn.execute("INSERT INTO messages (name, email, message) VALUES (?, ?, ?)",
                          (name, email, message))
         return redirect('/')  # Redirect to home after sending

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ Jinja2==3.1.6
 MarkupSafe==3.0.2
 packaging==24.2
 Werkzeug==3.1.3
+vercel-wsgi==0.2.0

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,12 @@
+{
+  "functions": {
+    "api/index.py": {
+      "runtime": "python3.11"
+    }
+  },
+  "routes": [
+    { "src": "/static/(.*)", "dest": "/static/$1" },
+    { "src": "/(.*)", "dest": "/api/index.py" }
+  ]
+}
+


### PR DESCRIPTION
Add Vercel serverless configuration to deploy the Flask portfolio app.

The changes include creating a Vercel-specific entry point (`api/index.py`), configuring Vercel routing (`vercel.json`), adding the `vercel-wsgi` dependency, and modifying the Flask app to use an ephemeral database path (`/tmp/database.db`) for serverless compatibility.

---
<a href="https://cursor.com/background-agent?bcId=bc-626b4a21-6bce-4ce0-92f3-2316d46d1846">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-626b4a21-6bce-4ce0-92f3-2316d46d1846">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

