### PR TITLE
Fix Farcaster manifest for Vercel deployment

### DIFF
--- a/.well-known/farcaster.json
+++ b/.well-known/farcaster.json
@@ -1,0 +1,13 @@
+{
+  "accountAssociation": {
+    "header": "REPLACE_WITH_WARPCAST_HEADER",
+    "payload": "REPLACE_WITH_WARPCAST_PAYLOAD",
+    "signature": "REPLACE_WITH_WARPCAST_SIGNATURE"
+  },
+  "frame": {
+    "version": "1",
+    "name": "Your App Name",
+    "iconUrl": "https://portfolio-tau-self-82.vercel.app/static/IMG_1774.jpeg",
+    "homeUrl": "https://portfolio-tau-self-82.vercel.app"
+  }
+}

--- a/app.py
+++ b/app.py
@@ -1,5 +1,6 @@
-from flask import Flask, render_template, request, redirect
+from flask import Flask, render_template, request, redirect, send_from_directory
 import sqlite3
+import os
 
 app = Flask(__name__)
 
@@ -41,6 +42,15 @@ def contact():
                          (name, email, message))
         return redirect('/')  # Redirect to home after sending
     return render_template("contact.html")
+
+# 4️⃣ Farcaster manifest route
+@app.route('/.well-known/farcaster.json')
+def farcaster_manifest():
+    return send_from_directory(
+        os.path.join(app.root_path, '.well-known'),
+        'farcaster.json',
+        mimetype='application/json'
+    )
 
 # 5️⃣ Run the app
 if __name__ == '__main__':


### PR DESCRIPTION
Add Farcaster manifest support to enable account association.

---
<a href="https://cursor.com/background-agent?bcId=bc-5482db82-ae54-485d-b8e4-b1a5efed8e0d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5482db82-ae54-485d-b8e4-b1a5efed8e0d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

